### PR TITLE
Added go-get support using engo.io domain

### DIFF
--- a/ecs/index.html
+++ b/ecs/index.html
@@ -1,0 +1,9 @@
+<html>
+    <head>
+        <meta name="go-import" content="engo.io/ecs git https://engo.io/ecs">
+        <meta name="go-source" content="engo.io/ecs _ https://github.com/EngoEngine/ecs/tree/master{/dir} https://github.com/EngoEngine/ecs/blob/master{/dir}/{file}#L{line}">
+    </head>
+    <body>
+go get engo.io/ecs
+</body>
+</html>

--- a/engo/index.html
+++ b/engo/index.html
@@ -1,0 +1,9 @@
+<html>
+    <head>
+        <meta name="go-import" content="engo.io/engo git https://engo.io/engo">
+        <meta name="go-source" content="engo.io/engo _ https://github.com/EngoEngine/engo/tree/master{/dir} https://github.com/EngoEngine/engo/blob/master{/dir}/{file}#L{line}">
+    </head>
+    <body>
+go get engo.io/engo
+</body>
+</html>


### PR DESCRIPTION
As discussed in the gitter chat you can now use these import statements:

``` go
import (
    "engo.io/engo"
    "engo.io/ecs"
)
```
