### PR TITLE
Added placeholder for tutorials at engo.io

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,5 +6,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://engo.io" # the base hostname & protocol for your site
 github_username: EngoEngine
 
+include: ['_pages', "_tutorials"]
+
 # Build settings
 markdown: kramdown

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <footer class="row column">
     <hr>
-    <p>&copy; 2016 EngoEngine - MIT Licensed
+    <p>&copy; 2016 <a href="https://github.com/EngoEngine/" target="_blank">EngoEngine</a> - MIT Licensed
 </footer>
 
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,11 +2,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
 	
-	<title>Engo</title>
 	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/foundation/6.2.0/foundation.min.css">
 	<style type="text/css">
 		body { text-align: center; }
 		.row { max-width: 35rem; }
 		footer p { font-size: small; color: gray; }
 	</style>
-</head>

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -2,12 +2,16 @@
 
 <html lang="en" class="no-js">
     {% include head.html %}
+    <title>{{page.number}} &raquo; {{page.title}} in engo</title>
     </head>
 
     <body>
         {% include header.html %}
 
         <article>
+        <div class="row column">
+            <h2><small>Tutorial {{page.number}}</small><br>{{page.title}}</h2>
+        </div>
         <div class="row column">
             {{ content }}
         </div>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+---
+layout: default
+title: Welcome
+---
+
+<h2>{{ title }}</h2>
+
+<p>Engo is an open-source 2D game engine written in <a href="https://golang.org" target="_blank">Go</a>. It uses the Entity-Component-System paradigm. The code is available on <a href="https://github.com/EngoEngine/engo" target="_blank">GitHub</a>. If you encounter any problems, find any bugs, or want to request a feature, you can <a href="https://github.com/EngoEngine/engo/issues/new" target="_blank">open an issue</a> or chat with us on <a href="https://gitter.im/EngoEngine/engo">gitter</a>. </p>
+
+<p>We're currently still developing this website (it's on <a href="https://github.com/EngoEngine/engoengine.github.io" target="_blank">GitHub</a> too!), so please be patient while we begin to fill it out. Ideas and content requestes can be filed <a href="https://github.com/EngoEngine/engoengine.github.io/issues/new" target="_blank">here</a>. </p>
+
+<h2>Tutorials</h2>
+
+<ul class="button-group stacked">
+{% for tut in site.categories.tutorials reversed %}
+<li><a class="button" href="{{tut.url}}">{{ tut.title }}</a></li>
+{% endfor %}
+</ul>
+
+<h2>Links</h2>
+
+{% include links.html %}

--- a/index.md
+++ b/index.md
@@ -1,9 +1,0 @@
----
-layout: default
----
-
-Engo is an open-source 2D game engine written in [Go](https://golang.org). It uses the Entity-Component-System paradigm. The code is available on [GitHub](https://github.com/EngoEngine/engo). If you encounter any problems, find any bugs, or want to request a feature, you can [open an issue](https://github.com/EngoEngine/engo/issues/new) or chat with us on [Gitter](https://gitter.im/EngoEngine/engo).
-
-We're currently still developing this website (it's on [GitHub](https://github.com/EngoEngine/engoengine.github.io) too!), so please be patient while we begin to fill it out. Ideas and content requestes can be filed [here](https://github.com/EngoEngine/engoengine.github.io/issues/new)).
-
-{% include links.html %}

--- a/tutorials/_posts/2016-04-04-01-hello-world.md
+++ b/tutorials/_posts/2016-04-04-01-hello-world.md
@@ -1,0 +1,9 @@
+---
+layout: tutorial
+title: Hello World
+permalink: /tutorials/01-hello-world
+number: 1
+---
+
+This will be where our first tutorial in engo will be posted. Be sure to check this page again in a few days! 
+

--- a/tutorials/_posts/2016-04-04-02-custom-systems.md
+++ b/tutorials/_posts/2016-04-04-02-custom-systems.md
@@ -1,0 +1,9 @@
+---
+layout: tutorial
+title: Custom Systems
+number: 2
+permalink: /tutorials/2-custom-systems
+---
+
+This will be where our second tutorial (about creating custom Systems) in engo will be posted. Be sure to check this page again in a few days!
+


### PR DESCRIPTION
Actual tutorials may be added, but not in this PR. 

Would anyone please review this? :-)

(Simply checkout the `tutorials` branch, enter `jekyll serve`, and visit `http://localhost:4000`)
