### PR TITLE
Clarify tutorial point

### DIFF
--- a/tutorials/_posts/2016-04-11-camera-movement.md
+++ b/tutorials/_posts/2016-04-11-camera-movement.md
@@ -43,7 +43,7 @@ func (*myScene) Setup(world *ecs.World) {
 	world.AddSystem(&engo.MouseSystem{})
 	world.AddSystem(&engo.RenderSystem{})
 	kbs := common.NewKeyboardScroller(
-		KeyboardScrollSpeed, engo.DefaultHorizontalAxis,
+		400, engo.DefaultHorizontalAxis,
 		engo.DefaultVerticalAxis))
 	world.AddSystem(kbs)
 
@@ -52,9 +52,9 @@ func (*myScene) Setup(world *ecs.World) {
 
 {% endhighlight %}
 
-The magic number `400` here, is the speed at which the camera should move. It's mostly a relative number, meaning:
+The magic number `400` here is the speed at which the camera moves. It's mostly a relative number, meaning:
 at zoom level 1x (so everything is at 100%), it will move 400 units per second. You can change this to any value 
-you feel fits to your game. 
+you feel fits to your game.
 
 We must also tell Engo what keys will move us around. For now, we can simply use the default settings to do so, by changing our run options:
 


### PR DESCRIPTION
The text immediately after clarifies the role of a "magical" literal, but right now the component is passed a KeyboardScrollSpeed variable. The other camera system examples that follow all use literals rather than variables, so converting the variable to a literal seems consistent.
