### PR TITLE
Add import path for engo/common. Fixes EngoEngine/engo#344.

### DIFF
--- a/engo/common/index.html
+++ b/engo/common/index.html
@@ -1,0 +1,13 @@
+---
+permalink: /engo/common
+---
+
+<html>
+    <head>
+        <meta name="go-import" content="engo.io/engo git https://github.com/EngoEngine/engo">
+        <meta name="go-source" content="engo.io/engo https://github.com/EngoEngine/engo https://github.com/EngoEngine/engo/tree/master{/dir} https://github.com/EngoEngine/engo/blob/master{/dir}/{file}#L{line}">
+    </head>
+    <body>
+go get engo.io/engo/common
+</body>
+</html>


### PR DESCRIPTION
I hope this should be enough to fix EngoEngine/engo#344. Otherwise, we may try something else.