### PR TITLE
add handler for engo.io/engo/common

### DIFF
--- a/engo/common/index.html
+++ b/engo/common/index.html
@@ -1,0 +1,13 @@
+---
+permalink: /engo/common
+---
+
+<html>
+    <head>
+        <meta name="go-import" content="engo.io/engo/common git https://github.com/EngoEngine/engo/common">
+        <meta name="go-source" content="engo.io/engo/common https://github.com/EngoEngine/engo/common https://github.com/EngoEngine/engo/tree/master/common{/dir} https://github.com/EngoEngine/engo/blob/master/common{/dir}/{file}#L{line}">
+    </head>
+    <body>
+go get engo.io/engo/common
+</body>
+</html>


### PR DESCRIPTION
Godoc is unable to build the documentation for the common package due to it's path being "engo.io/engo/common" which gives it a 404 page. Possible fix for https://github.com/EngoEngine/engo/issues/344, since adding doc.go and a package comment didn't work. Also, https://godoc.org/github.com/EngoEngine/engo/common works on godoc but https://godoc.org/engo.io/engo/common does not