### PR TITLE
Setup parameter type is wrong in hello world tutorial

### DIFF
--- a/tutorials/_posts/2016-04-09-hello-world.md
+++ b/tutorials/_posts/2016-04-09-hello-world.md
@@ -67,7 +67,7 @@ func (*myScene) Preload() {}
 
 // Setup is called before the main loop starts. It allows you
 // to add entities and systems to your Scene.
-func (*myScene) Setup(*ecs.World) {}
+func (*myScene) Setup(engo.Updater) {}
 
 func main() {
 	opts := engo.RunOptions{


### PR DESCRIPTION
Following the hello world tutorial on the current version of engo results in a type error:
```
cannot use myScene literal (type *myScene) as type engo.Scene in argument to engo.Run:
	*myScene does not implement engo.Scene (wrong type for Setup method)
		have Setup(*ecs.World)
		want Setup(engo.Updater)
```
Once we pass in the type that `Setup` is expecting, we can compile and get the window.
<img width="512" alt="screen shot 2018-04-17 at 9 05 13 pm" src="https://user-images.githubusercontent.com/4822375/38906189-182cbccc-4283-11e8-8673-45b1bd6aea40.png">
