### PR TITLE
fixed some typos / updates to engo that changed code

### DIFF
--- a/tutorials/_posts/2016-04-09-hello-world.md
+++ b/tutorials/_posts/2016-04-09-hello-world.md
@@ -143,11 +143,16 @@ In order to add the `RenderSystem` to our `engo`-game, we want to add it within 
 `RenderSystem` is located in the engo.io/engo/common package, along with other frequently used systems.
 
 {% highlight go %}
-import "engo.io/engo/common"
+import (
+	"engo.io/ecs"
+	"engo.io/engo"
+	"engo.io/engo/common"
+)
 
 // Setup is called before the main loop starts. It allows you
 // to add entities and systems to your Scene.
-func (*myScene) Setup(world *ecs.World) {
+func (*myScene) Setup(u engo.Updater) {
+	world, _ := u.(*ecs.World)
 	world.AddSystem(&common.RenderSystem{})
 }
 {% endhighlight %}

--- a/tutorials/_posts/2016-04-10-first-system.md
+++ b/tutorials/_posts/2016-04-10-first-system.md
@@ -86,7 +86,7 @@ func (*myScene) Setup(world *ecs.World) {
 
 > ##### How do we know it works?
 > At the moment, we can't be sure it actually works, right?
-> Each system can optionally implement `New(*eces.World)`, which will be called whenever the System is added to the
+> Each system can optionally implement `New(*ecs.World)`, which will be called whenever the System is added to the
 > scene. 
 > 
 > Let's create a `New` function for our `CityBuildingSystem`  like this:
@@ -109,7 +109,7 @@ First, we need to tell the Engo to listen for the F1 key press. We'll do this by
 Add the following line to the `Setup` function for your `Scene`.
 {% highlight go %}
 func (*myScene) Setup(world *ecs.World) {
-	engo.Input.RegisterButton("AddCity", engo.F1)
+	engo.Input.RegisterButton("AddCity", engo.KeyF1)
 	common.SetBackground(color.White)
 	world.AddSystem(&common.RenderSystem{})
 	

--- a/tutorials/_posts/2016-04-11-camera-movement.md
+++ b/tutorials/_posts/2016-04-11-camera-movement.md
@@ -44,7 +44,7 @@ func (*myScene) Setup(world *ecs.World) {
 	world.AddSystem(&engo.RenderSystem{})
 	kbs := common.NewKeyboardScroller(
 		400, engo.DefaultHorizontalAxis,
-		engo.DefaultVerticalAxis))
+		engo.DefaultVerticalAxis)
 	world.AddSystem(kbs)
 
 	world.AddSystem(&systems.CityBuildingSystem{})
@@ -83,8 +83,8 @@ It uses the same scroll-speed as the KeyboardScroller (`400`) in this case. The 
 of pixels the cursor has to be near the edge of the screen in order to count as being "near the edge". The higher the 
 number, the sooner this system will decide to move the camera around. 
 
-#### ScrollZoomer
-As with the other two, the `ScrollZoomer` is a `System` we can add to our game. 
+#### MouseZoomer
+As with the other two, the `MouseZoomer` is a `System` we can add to our game. 
 
 {% highlight go %}
 world.AddSystem(&common.MouseZoomer{-0.125})


### PR DESCRIPTION
Hi Engo team,
I was running through your tutorial this afternoon and got tripped up on a few lines that look to be typos or outdated with respect to the engine. This PR updates a couple of code snippets and section names so that they are accurate with the current state of the engine.