### PR TITLE
Fix engo vs common mismatch in tutorial 4 (HUD)

### DIFF
--- a/tutorials/_posts/2018-05-30-hud.md
+++ b/tutorials/_posts/2018-05-30-hud.md
@@ -51,14 +51,14 @@ using the `WindowHeight()`, and subtracting the height of our HUD (in this case
 {% highlight go %}
 type HUD struct {
 	ecs.BasicEntity
-	engo.RenderComponent
-	engo.SpaceComponent
+	common.RenderComponent
+	common.SpaceComponent
 }
 {% endhighlight %}
 
 {% highlight go %}
 hud := HUD{BasicEntity: ecs.NewBasic()}
-hud.SpaceComponent = engo.SpaceComponent{
+hud.SpaceComponent = common.SpaceComponent{
       Position: engo.Point{0, engo.WindowHeight() - 200},
       Width:    200,
       Height:   200,
@@ -90,13 +90,13 @@ It is a bit verbose at the moment, so we're not going in too much depth into thi
 hudImage := image.NewUniform(color.RGBA{205, 205, 205, 255})
 hudNRGBA := common.ImageToNRGBA(hudImage, 200, 200)
 hudImageObj := common.NewImageObject(hudNRGBA)
-hudTexture := engo.NewTextureSingle(hudImageObj)
+hudTexture := common.NewTextureSingle(hudImageObj)
 
-hud.RenderComponent = engo.NewRenderComponent(
-  hudTexture,
-  engo.Point{1, 1},
-  "hud",
-)
+hud.RenderComponent = common.RenderComponent{
+  Drawable: hudTexture,
+  Scale:    engo.Point{1, 1},
+  Repeat:   common.Repeat,
+}
 {% endhighlight %}
 
 But if we were to add this `RenderComponent` to our entity, and add the entity to our world, we would notice that this
@@ -119,7 +119,7 @@ hud.RenderComponent.SetZIndex(1)
 // And finally add it to the world:
 for _, system := range world.Systems() {
   switch sys := system.(type) {
-    case *engo.RenderSystem:
+    case *common.RenderSystem:
       sys.Add(&hud.BasicEntity, &hud.RenderComponent, &hud.SpaceComponent)
   }
 }


### PR DESCRIPTION
It should now match the example code from https://github.com/EngoEngine/TrafficManager/blob/04-hud/traffic.go