### PR TITLE
Matching syntax to the code in the tutorial codebase repo

### DIFF
--- a/concepts/animation.md
+++ b/concepts/animation.md
@@ -62,7 +62,8 @@ now we need to take a look at our spritesheet and check which frames correspond 
 once we have that jotted down we can in setup method instantiate Spritesheet and AnimationAction
 
 ```go
-func (*DefaultScene) Setup(w *ecs.World)) {
+func (*myScene) Setup(u engo.Updater) {
+	world, _ := u.(*ecs.World)
   game.AddSystem(&engo.RenderSystem{})
   game.AddSystem(&engo.AnimationSystem{})
 

--- a/tutorials/_posts/2016-04-10-first-system.md
+++ b/tutorials/_posts/2016-04-10-first-system.md
@@ -76,7 +76,8 @@ the `Entity` we created in the last tutorial.
 {% highlight go %}
 // Setup is called before the main loop starts. It allows you
 // to add entities and systems to your Scene.
-func (*myScene) Setup(world *ecs.World) {
+func (*myScene) Setup(u engo.Updater) {
+	world, _ := u.(*ecs.World)
 	common.SetBackground(color.White)
 	world.AddSystem(&common.RenderSystem{})
 
@@ -108,7 +109,8 @@ First, we need to tell the Engo to listen for the F1 key press. We'll do this by
 
 Add the following line to the `Setup` function for your `Scene`.
 {% highlight go %}
-func (*myScene) Setup(world *ecs.World) {
+func (*myScene) Setup(u engo.Updater) {
+	world, _ := u.(*ecs.World)
 	engo.Input.RegisterButton("AddCity", engo.KeyF1)
 	common.SetBackground(color.White)
 	world.AddSystem(&common.RenderSystem{})
@@ -214,7 +216,8 @@ The first thing you want to do, is add the `MouseSystem` to your `Scene`:
 
 {% highlight go %}
 // Setup is called before the main loop starts. It allows you to add entities and systems to your Scene.
-func (*myGame) Setup(world *ecs.World) {
+func (*myScene) Setup(u engo.Updater) {
+	world, _ := u.(*ecs.World)
 	engo.Input.RegisterButton("AddCity", engo.F1)
 	common.SetBackground(color.White)
 

--- a/tutorials/_posts/2016-04-11-camera-movement.md
+++ b/tutorials/_posts/2016-04-11-camera-movement.md
@@ -37,7 +37,8 @@ The `KeyboardScroller` is another System - one that listens for keyboard input a
 Let's add one in the `Setup` function of our game:
 {% highlight go %}
 // Setup is called before the main loop starts. It allows you to add entities and systems to your Scene.
-func (*myScene) Setup(world *ecs.World) {
+func (*myScene) Setup(u engo.Updater) {
+	world, _ := u.(*ecs.World)
 	engo.SetBackground(color.White)
 
 	world.AddSystem(&engo.MouseSystem{})


### PR DESCRIPTION
Fix the code to match the actual code base in the repository.  I'm assuming the code in the .md files is now outdated

Should prevent other newcomers like me getting confused when trying to go through the tutorial and learn the framework.